### PR TITLE
Dynamic Stickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2.0.1 [Non-Functional]
+
+- Changed how the plugin gets stickers. 
+    - I am now able to update the stickers without you having to download a new version.
+    
 ## 2.0.0 [New Themes!]
 
 - Added Setting Menu Option

--- a/buildSrc/BuildThemes.ts
+++ b/buildSrc/BuildThemes.ts
@@ -223,7 +223,7 @@ const readTemplates = (templatePaths: string[]): TemplateTypes => {
 };
 
 
-function readSticker(
+function resolveStickerPath(
   themeDefinitonPath: string,
   themeDefinition: MasterDokiThemeDefinition,
 ) {
@@ -231,8 +231,7 @@ function readSticker(
     path.resolve(themeDefinitonPath, '..'),
     themeDefinition.stickers.normal || themeDefinition.stickers.default
   );
-  const stickerDefinition = stickerPath.substr(masterThemeDefinitionDirectoryPath.length + '/definitions'.length);
-  return `https://doki.assets.unthrottled.io/stickers/vscode${stickerDefinition}`;
+  return stickerPath.substr(masterThemeDefinitionDirectoryPath.length + '/definitions'.length);
 }
 
 
@@ -288,7 +287,7 @@ walkDir(path.resolve(masterThemeDefinitionDirectoryPath, 'templates'))
         'icons'
       ]),
       colors: dokiTheme.theme.colors,
-      sticker: readSticker(
+      sticker: resolveStickerPath(
         dokiTheme.path,
         dokiDefinition
       ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doki-theme-hyper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The Doki Theme for Hyper",
   "main": "build/index.js",
   "repository": "https://github.com/Unthrottled/doki-theme-hyper.git",

--- a/src/AppInitialization.ts
+++ b/src/AppInitialization.ts
@@ -10,10 +10,8 @@ export default () => {
   const browserWindow = app.getLastFocusedWindow()
   if (browserWindow && !listener) {
     attemptToUpdateSticker();
-    console.log("initializing listeners!!!");
     listener = (_, channel) => {
       if (channel[0] === SET_THEME) {
-        console.log('heard set theme');
         attemptToUpdateSticker();
       }
     }

--- a/src/AppInitialization.ts
+++ b/src/AppInitialization.ts
@@ -17,5 +17,4 @@ export default () => {
     }
     browserWindow.webContents.on('ipc-message', listener)
   }
-
 }

--- a/src/AppInitialization.ts
+++ b/src/AppInitialization.ts
@@ -1,10 +1,10 @@
-import { attemptToUpdateSticker } from './StickerUpdateService';
-import { app, Input } from 'electron';
-import { SET_THEME } from './settings';
+import {attemptToUpdateSticker} from './StickerUpdateService';
+import {app} from 'electron';
+import {SET_THEME} from './settings';
 
 let listener: (event: Event,
-  channel: string,
-  ...args: any[]) => void;
+               channel: string,
+               ...args: any[]) => void;
 
 export default () => {
   const browserWindow = app.getLastFocusedWindow()
@@ -16,5 +16,6 @@ export default () => {
       }
     }
     browserWindow.webContents.on('ipc-message', listener)
-  };
+  }
+
 }

--- a/src/AppInitialization.ts
+++ b/src/AppInitialization.ts
@@ -1,0 +1,22 @@
+import { attemptToUpdateSticker } from './StickerUpdateService';
+import { app, Input } from 'electron';
+import { SET_THEME } from './settings';
+
+let listener: (event: Event,
+  channel: string,
+  ...args: any[]) => void;
+
+export default () => {
+  const browserWindow = app.getLastFocusedWindow()
+  if (browserWindow && !listener) {
+    attemptToUpdateSticker();
+    console.log("initializing listeners!!!");
+    listener = (_, channel) => {
+      if (channel[0] === SET_THEME) {
+        console.log('heard set theme');
+        attemptToUpdateSticker();
+      }
+    }
+    browserWindow.webContents.on('ipc-message', listener)
+  };
+}

--- a/src/ENV.ts
+++ b/src/ENV.ts
@@ -1,0 +1,5 @@
+
+export const ASSETS_URL = `https://doki.assets.unthrottled.io`;
+export const VSCODE_ASSETS_URL = `${ASSETS_URL}/stickers/vscode`;
+export const BACKGROUND_ASSETS_URL = `${ASSETS_URL}/backgrounds`;
+export const SCREENSHOT_ASSETS_URL = `${ASSETS_URL}/screenshots`;

--- a/src/ENV.ts
+++ b/src/ENV.ts
@@ -1,4 +1,3 @@
-
 export const ASSETS_URL = `https://doki.assets.unthrottled.io`;
 export const VSCODE_ASSETS_URL = `${ASSETS_URL}/stickers/vscode`;
 export const BACKGROUND_ASSETS_URL = `${ASSETS_URL}/backgrounds`;

--- a/src/RESTClient.ts
+++ b/src/RESTClient.ts
@@ -1,5 +1,5 @@
 import https from 'https';
-import { Transform as Stream } from 'stream';
+import {Transform as Stream} from 'stream';
 
 export const performGet = (url: string): Promise<Stream> => {
   return new Promise((resolve, reject) => {

--- a/src/RESTClient.ts
+++ b/src/RESTClient.ts
@@ -1,0 +1,18 @@
+import https from 'https';
+import { Transform as Stream } from 'stream';
+
+export const performGet = (url: string): Promise<Stream> => {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      const inputStream = new Stream();
+      res.on('data', (d) => {
+        inputStream.push(d);
+      });
+      res.on('end', () => {
+        resolve(inputStream);
+      });
+    }).on('error', (e) => {
+      reject(e);
+    }).end();
+  });
+};

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -29,6 +29,7 @@ const downloadSticker = async (stickerPath: string, localDestination: string) =>
   const stickerUrl = `${VSCODE_ASSETS_URL}${stickerPath}`;
   console.log(`Downloading image: ${stickerUrl}`);
   const stickerInputStream = await performGet(stickerUrl);
+  console.log('Image downloaded');
   fs.writeFileSync(localDestination, stickerInputStream.read());
 };
 

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -4,7 +4,7 @@ import { resolveLocalStickerPath, isStickerNotCurrent, StickerUpdateStatus } fro
 import { performGet } from "./RESTClient";
 import { VSCODE_ASSETS_URL } from "./ENV";
 import { DokiTheme } from './themeTemp';
-import {BrowserWindow} from 'electron';
+import { app } from 'electron';
 
 export enum InstallStatus {
   INSTALLED, NOT_INSTALLED, FAILURE
@@ -13,12 +13,17 @@ export enum InstallStatus {
 const main = require.main || { filename: 'yeet' };
 export const workbenchDirectory = path.join(path.dirname(main.filename), 'vs', 'workbench');
 
-
+function mkdirp(dir: string) {
+  if (fs.existsSync(dir)) { return true }
+  const dirname = path.dirname(dir)
+  mkdirp(dirname);
+  fs.mkdirSync(dir);
+}
 
 const downloadSticker = async (stickerPath: string, localDestination: string) => {
   const parentDirectory = path.dirname(localDestination);
   if (!fs.existsSync(parentDirectory)) {
-    fs.mkdirSync(parentDirectory, { recursive: true });
+    mkdirp(parentDirectory);
   }
 
   const stickerUrl = `${VSCODE_ASSETS_URL}${stickerPath}`;
@@ -34,11 +39,10 @@ export async function getLatestStickerAndBackground(
   const localStickerPath = resolveLocalStickerPath(
     dokiTheme.sticker
   );
-  if (stickerStatus === StickerUpdateStatus.STALE || 
+  if (stickerStatus === StickerUpdateStatus.STALE ||
     !fs.existsSync(localStickerPath) ||
     await isStickerNotCurrent(dokiTheme.sticker, localStickerPath)) {
     await downloadSticker(dokiTheme.sticker, localStickerPath);
-    send('yeet','aoeu')
   }
 }
 
@@ -46,12 +50,12 @@ export async function installSticker(
   dokiTheme: DokiTheme,
   stickerStatus: StickerUpdateStatus = StickerUpdateStatus.NOT_CHECKED
 ): Promise<boolean> {
-    try {
-      await getLatestStickerAndBackground(dokiTheme, stickerStatus);
-      return true;
-    } catch (e) {
-      console.error('Unable to install sticker!', e);
-    }
+  try {
+    await getLatestStickerAndBackground(dokiTheme, stickerStatus);
+    return true;
+  } catch (e) {
+    console.error('Unable to install sticker!', e);
+  }
 
   return false;
 }

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -1,0 +1,57 @@
+import path from 'path';
+import fs from "fs";
+import { resolveLocalStickerPath, isStickerNotCurrent, StickerUpdateStatus } from "./StickerUpdateService";
+import { performGet } from "./RESTClient";
+import { VSCODE_ASSETS_URL } from "./ENV";
+import { DokiTheme } from './themeTemp';
+import {BrowserWindow} from 'electron';
+
+export enum InstallStatus {
+  INSTALLED, NOT_INSTALLED, FAILURE
+}
+
+const main = require.main || { filename: 'yeet' };
+export const workbenchDirectory = path.join(path.dirname(main.filename), 'vs', 'workbench');
+
+
+
+const downloadSticker = async (stickerPath: string, localDestination: string) => {
+  const parentDirectory = path.dirname(localDestination);
+  if (!fs.existsSync(parentDirectory)) {
+    fs.mkdirSync(parentDirectory, { recursive: true });
+  }
+
+  const stickerUrl = `${VSCODE_ASSETS_URL}${stickerPath}`;
+  console.log(`Downloading image: ${stickerUrl}`);
+  const stickerInputStream = await performGet(stickerUrl);
+  fs.writeFileSync(localDestination, stickerInputStream.read());
+};
+
+export async function getLatestStickerAndBackground(
+  dokiTheme: DokiTheme,
+  stickerStatus: StickerUpdateStatus
+) {
+  const localStickerPath = resolveLocalStickerPath(
+    dokiTheme.sticker
+  );
+  if (stickerStatus === StickerUpdateStatus.STALE || 
+    !fs.existsSync(localStickerPath) ||
+    await isStickerNotCurrent(dokiTheme.sticker, localStickerPath)) {
+    await downloadSticker(dokiTheme.sticker, localStickerPath);
+    send('yeet','aoeu')
+  }
+}
+
+export async function installSticker(
+  dokiTheme: DokiTheme,
+  stickerStatus: StickerUpdateStatus = StickerUpdateStatus.NOT_CHECKED
+): Promise<boolean> {
+    try {
+      await getLatestStickerAndBackground(dokiTheme, stickerStatus);
+      return true;
+    } catch (e) {
+      console.error('Unable to install sticker!', e);
+    }
+
+  return false;
+}

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -1,20 +1,14 @@
 import path from 'path';
 import fs from "fs";
-import { resolveLocalStickerPath, isStickerNotCurrent, StickerUpdateStatus } from "./StickerUpdateService";
-import { performGet } from "./RESTClient";
-import { VSCODE_ASSETS_URL } from "./ENV";
-import { DokiTheme } from './themeTemp';
-import { app } from 'electron';
-
-export enum InstallStatus {
-  INSTALLED, NOT_INSTALLED, FAILURE
-}
-
-const main = require.main || { filename: 'yeet' };
-export const workbenchDirectory = path.join(path.dirname(main.filename), 'vs', 'workbench');
+import {isStickerNotCurrent, resolveLocalStickerPath, StickerUpdateStatus} from "./StickerUpdateService";
+import {performGet} from "./RESTClient";
+import {VSCODE_ASSETS_URL} from "./ENV";
+import {DokiTheme} from './themeTemp';
 
 function mkdirp(dir: string) {
-  if (fs.existsSync(dir)) { return true }
+  if (fs.existsSync(dir)) {
+    return true
+  }
   const dirname = path.dirname(dir)
   mkdirp(dirname);
   fs.mkdirSync(dir);

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -1,12 +1,12 @@
-import { performGet } from './RESTClient';
-import { installSticker } from './StickerService';
+import {performGet} from './RESTClient';
+import {installSticker} from './StickerService';
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
-import { VSCODE_ASSETS_URL } from './ENV';
-import { getTheme } from './config';
-import { BrowserWindow, app } from 'electron';
-import { STICKER_UPDATED } from './settings';
+import {VSCODE_ASSETS_URL} from './ENV';
+import {getTheme} from './config';
+import {app, BrowserWindow} from 'electron';
+import {STICKER_UPDATED} from './settings';
 
 const fetchRemoteChecksum = async (stickerPath: string) => {
   const checksumUrl = `${VSCODE_ASSETS_URL}${stickerPath}.checksum.txt`;
@@ -52,6 +52,7 @@ export const isStickerNotCurrent = async (
     return false;
   }
 };
+
 export enum StickerUpdateStatus {
   CURRENT, STALE, NOT_CHECKED,
 }

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -1,0 +1,62 @@
+import { performGet } from './RESTClient';
+import { installSticker } from './StickerService';
+import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
+import { VSCODE_ASSETS_URL } from './ENV';
+import { getTheme } from './config';
+
+const fetchRemoteChecksum = async (stickerPath: string) => {
+  const checksumUrl = `${VSCODE_ASSETS_URL}${stickerPath}.checksum.txt`;
+  console.log(`Fetching checksum: ${checksumUrl}`);
+  const checkSumInputStream = await performGet(checksumUrl);
+  return checkSumInputStream.setEncoding('utf8').read();
+};
+
+export const resolveLocalStickerPath = (
+  stickerPath: string,
+): string => {
+  const safeStickerPath = stickerPath.replace('/', path.sep);
+  return path.join(__dirname, 'stickers', safeStickerPath);
+};
+
+export function createChecksum(data: Buffer | string): string {
+  return crypto.createHash('md5')
+    .update(data)
+    .digest('hex');
+}
+
+const calculateFileChecksum = (filePath: string): string => {
+  const fileRead = fs.readFileSync(filePath);
+  return createChecksum(fileRead);
+};
+
+const fetchLocalChecksum = async (localSticker: string) => {
+  return fs.existsSync(localSticker) ?
+    calculateFileChecksum(localSticker) : 'File not downloaded, bruv.';
+};
+
+export const isStickerNotCurrent = async (
+  stickerPath: string,
+  localStickerPath: string
+): Promise<boolean> => {
+  try {
+    const remoteChecksum = await fetchRemoteChecksum(stickerPath);
+    const localChecksum = await fetchLocalChecksum(localStickerPath);
+    return remoteChecksum !== localChecksum;
+  } catch (e) {
+    console.error('Unable to check for updates', e);
+    return false;
+  }
+};
+export enum StickerUpdateStatus {
+  CURRENT, STALE, NOT_CHECKED,
+}
+
+export const attemptToUpdateSticker = async () => {
+  const currentTheme = getTheme();
+  const localStickerPath = resolveLocalStickerPath(currentTheme.sticker);
+  if (await isStickerNotCurrent(currentTheme.sticker, localStickerPath)) {
+    await installSticker(currentTheme, StickerUpdateStatus.STALE);
+  }
+};

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -6,11 +6,13 @@ import crypto from 'crypto';
 import { VSCODE_ASSETS_URL } from './ENV';
 import { getTheme } from './config';
 import { BrowserWindow, app } from 'electron';
+import { STICKER_UPDATED } from './settings';
 
 const fetchRemoteChecksum = async (stickerPath: string) => {
   const checksumUrl = `${VSCODE_ASSETS_URL}${stickerPath}.checksum.txt`;
   console.log(`Fetching checksum: ${checksumUrl}`);
   const checkSumInputStream = await performGet(checksumUrl);
+  console.log('Checksum fetched!');
   return checkSumInputStream.setEncoding('utf8').read();
 };
 
@@ -61,7 +63,7 @@ export const attemptToUpdateSticker = async (browserWindow?: BrowserWindow) => {
     await installSticker(currentTheme, StickerUpdateStatus.STALE);
     const resolvedBrowserWindow = browserWindow || app.getLastFocusedWindow();
     if (resolvedBrowserWindow) {
-      resolvedBrowserWindow.webContents.send('yeet', 'aoeu');
+      resolvedBrowserWindow.webContents.send(STICKER_UPDATED);
     }
   }
 };

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import crypto from 'crypto';
 import { VSCODE_ASSETS_URL } from './ENV';
 import { getTheme } from './config';
+import { BrowserWindow, app } from 'electron';
 
 const fetchRemoteChecksum = async (stickerPath: string) => {
   const checksumUrl = `${VSCODE_ASSETS_URL}${stickerPath}.checksum.txt`;
@@ -53,10 +54,14 @@ export enum StickerUpdateStatus {
   CURRENT, STALE, NOT_CHECKED,
 }
 
-export const attemptToUpdateSticker = async () => {
+export const attemptToUpdateSticker = async (browserWindow?: BrowserWindow) => {
   const currentTheme = getTheme();
   const localStickerPath = resolveLocalStickerPath(currentTheme.sticker);
   if (await isStickerNotCurrent(currentTheme.sticker, localStickerPath)) {
     await installSticker(currentTheme, StickerUpdateStatus.STALE);
+    const resolvedBrowserWindow = browserWindow || app.getLastFocusedWindow();
+    if (resolvedBrowserWindow) {
+      resolvedBrowserWindow.webContents.send('yeet', 'aoeu');
+    }
   }
 };

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -75,7 +75,6 @@ export const decorateTerm = (Term: any) =>
         ipcRenderer.send(SET_THEME, theme);
       });
       ipcRenderer.on(STICKER_UPDATED, () => {
-        console.log('new sticker!!');
         this.forceUpdate();
         window.store.dispatch({
           type: 'RE_RENDER_PLZ',

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -60,9 +60,12 @@ interface StickerState {
   imageLoaded: boolean;
 }
 
+const createCacheBuster = () =>
+  new Date().valueOf().toString(32);
+
 export const decorateTerm = (Term: any) => {
-  let cacheBuster: string = new Date().valueOf().toString(32);
- return class TerminalDecorator extends Component<any, StickerState> {
+  let cacheBuster: string = createCacheBuster();
+  return class TerminalDecorator extends Component<any, StickerState> {
     state = {
       imageLoaded: false,
     }
@@ -96,12 +99,12 @@ export const decorateTerm = (Term: any) => {
       const nextThemeState: ThemeState = nextProps[THEME_STATE];
       if (themeState.activeTheme.sticker !== nextThemeState.activeTheme.sticker) {
         this.setState({imageLoaded: false});
-        cacheBuster = new Date().valueOf().toString(32);
+        cacheBuster = createCacheBuster();
       }
     }
 
-    private imageError(){
-      cacheBuster = new Date().valueOf().toString(32);
+    private static imageError() {
+      cacheBuster = createCacheBuster();
     }
 
     render() {
@@ -123,7 +126,7 @@ export const decorateTerm = (Term: any) => {
                 <img
                   style={this.state.imageLoaded ? imageStyle : {display: 'none'}}
                   onLoad={() => this.setLoaded()}
-                  onError={()=> this.imageError()}
+                  onError={() => TerminalDecorator.imageError()}
                   src={TerminalDecorator.constructStickerUrl(themeState)}
                   alt={themeState.activeTheme.sticker}
                 /> : <></>

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -60,8 +60,9 @@ interface StickerState {
   imageLoaded: boolean;
 }
 
-export const decorateTerm = (Term: any) =>
-  class TerminalDecorator extends Component<any, StickerState> {
+export const decorateTerm = (Term: any) => {
+  let cacheBuster: string = new Date().valueOf().toString(32);
+ return class TerminalDecorator extends Component<any, StickerState> {
     state = {
       imageLoaded: false,
     }
@@ -95,7 +96,12 @@ export const decorateTerm = (Term: any) =>
       const nextThemeState: ThemeState = nextProps[THEME_STATE];
       if (themeState.activeTheme.sticker !== nextThemeState.activeTheme.sticker) {
         this.setState({imageLoaded: false});
+        cacheBuster = new Date().valueOf().toString(32);
       }
+    }
+
+    private imageError(){
+      cacheBuster = new Date().valueOf().toString(32);
     }
 
     render() {
@@ -117,6 +123,7 @@ export const decorateTerm = (Term: any) =>
                 <img
                   style={this.state.imageLoaded ? imageStyle : {display: 'none'}}
                   onLoad={() => this.setLoaded()}
+                  onError={()=> this.imageError()}
                   src={TerminalDecorator.constructStickerUrl(themeState)}
                   alt={themeState.activeTheme.sticker}
                 /> : <></>
@@ -132,6 +139,7 @@ export const decorateTerm = (Term: any) =>
 
     private static constructStickerUrl(themeState: ThemeState): string | undefined {
       const localStickerPath = resolveLocalStickerPath(themeState.activeTheme.sticker).replace(path.sep, '/');
-      return `${localStickerPath}?time=${new Date().valueOf().toString(32)}`;
+      return `${localStickerPath}?time=${cacheBuster}`;
     }
   };
+};

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Component } from 'react';
 import { THEME_STATE, ThemeState } from './reducer';
-import { SET_THEME, TOGGLE_STICKER } from './settings';
+import { SET_THEME, TOGGLE_STICKER, STICKER_UPDATED } from './settings';
 import path from 'path';
 import { resolveLocalStickerPath } from './StickerUpdateService';
 import {ipcRenderer, App} from 'electron';
@@ -65,12 +65,14 @@ export const decorateTerm = (Term: any) =>
         window.store.dispatch(reloadConfig(
           window.config.getConfig()
         ));
+        ipcRenderer.send(SET_THEME, theme);
       });
-      ipcRenderer.on('yeet', ()=>{
+      ipcRenderer.on(STICKER_UPDATED, ()=>{
         console.log('new sticker!!');
-        this.setState({
-          renderTime: new Date().valueOf().toString(32)
-        })
+        this.forceUpdate();
+        window.store.dispatch({
+          type: 'RE_RENDER_PLZ',
+        });
       })
       window.rpc.on(TOGGLE_STICKER, ()=>{
         window.store.dispatch({
@@ -96,12 +98,17 @@ export const decorateTerm = (Term: any) =>
           }}>
             {
               themeState.showSticker ? 
-              <img src={resolveLocalStickerPath(themeState.activeTheme.sticker).replace(path.sep, '/')}  
+              <img src={this.constructStickerUrl(themeState)}  
                    style={imageStyle}
                    alt={'Sticker!'}/> : <></>
             }
           </div>
         </div>
       )
+    }
+
+    private constructStickerUrl(themeState: ThemeState): string | undefined {
+      const localStickerPath = resolveLocalStickerPath(themeState.activeTheme.sticker).replace(path.sep, '/');
+      return `${localStickerPath}?time=${new Date().valueOf().toString(32)}`;
     }
   };

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -4,7 +4,7 @@ import { THEME_STATE, ThemeState } from './reducer';
 import { SET_THEME, TOGGLE_STICKER } from './settings';
 import path from 'path';
 import { resolveLocalStickerPath } from './StickerUpdateService';
-import {ipcRenderer} from 'electron';
+import {ipcRenderer, App} from 'electron';
 
 const passProps = (uid: any, parentProps: any, props: any) => Object.assign(props, {
   [THEME_STATE]: parentProps[THEME_STATE],
@@ -33,6 +33,15 @@ declare global {
     rpc: any,
     store: any,
   }
+  module Electron {
+    interface App {
+      getWindows: () => BrowserWindow[];
+      getLastFocusedWindow: () => BrowserWindow;
+    }
+    interface BrowserWindow {
+      rpc: any;
+    }
+  }
 }
 
 export const CONFIG_RELOAD = 'CONFIG_RELOAD';
@@ -59,9 +68,9 @@ export const decorateTerm = (Term: any) =>
       });
       ipcRenderer.on('yeet', ()=>{
         console.log('new sticker!!');
-        window.store.dispatch(reloadConfig(
-          window.config.getConfig()
-        ));
+        this.setState({
+          renderTime: new Date().valueOf().toString(32)
+        })
       })
       window.rpc.on(TOGGLE_STICKER, ()=>{
         window.store.dispatch({

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Component } from 'react';
 import { THEME_STATE, ThemeState } from './reducer';
 import { SET_THEME, TOGGLE_STICKER } from './settings';
+import path from 'path';
+import { resolveLocalStickerPath } from './StickerUpdateService';
+import {ipcRenderer} from 'electron';
 
 const passProps = (uid: any, parentProps: any, props: any) => Object.assign(props, {
   [THEME_STATE]: parentProps[THEME_STATE],
@@ -54,6 +57,12 @@ export const decorateTerm = (Term: any) =>
           window.config.getConfig()
         ));
       });
+      ipcRenderer.on('yeet', ()=>{
+        console.log('new sticker!!');
+        window.store.dispatch(reloadConfig(
+          window.config.getConfig()
+        ));
+      })
       window.rpc.on(TOGGLE_STICKER, ()=>{
         window.store.dispatch({
           type: TOGGLE_STICKER,
@@ -78,7 +87,7 @@ export const decorateTerm = (Term: any) =>
           }}>
             {
               themeState.showSticker ? 
-              <img src={themeState.activeTheme.sticker}  
+              <img src={resolveLocalStickerPath(themeState.activeTheme.sticker).replace(path.sep, '/')}  
                    style={imageStyle}
                    alt={'Sticker!'}/> : <></>
             }

--- a/src/decorator.tsx
+++ b/src/decorator.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import { Component } from 'react';
-import { THEME_STATE, ThemeState } from './reducer';
-import { SET_THEME, TOGGLE_STICKER, STICKER_UPDATED } from './settings';
+import React, {Component} from 'react';
+import {THEME_STATE, ThemeState} from './reducer';
+import {SET_THEME, STICKER_UPDATED, TOGGLE_STICKER} from './settings';
 import path from 'path';
-import { resolveLocalStickerPath } from './StickerUpdateService';
-import { ipcRenderer, App } from 'electron';
+import {resolveLocalStickerPath} from './StickerUpdateService';
+import {App, ipcRenderer} from 'electron';
 
 const passProps = (uid: any, parentProps: any, props: any) => Object.assign(props, {
   [THEME_STATE]: parentProps[THEME_STATE],
@@ -33,11 +32,13 @@ declare global {
     rpc: any,
     store: any,
   }
+
   module Electron {
     interface App {
       getWindows: () => BrowserWindow[];
       getLastFocusedWindow: () => BrowserWindow;
     }
+
     interface BrowserWindow {
       rpc: any;
     }
@@ -45,6 +46,7 @@ declare global {
 }
 
 export const CONFIG_RELOAD = 'CONFIG_RELOAD';
+
 export function reloadConfig(config: any) {
   const now = Date.now();
   return {
@@ -63,6 +65,7 @@ export const decorateTerm = (Term: any) =>
     state = {
       imageLoaded: false,
     }
+
     componentDidMount() {
       window.rpc.on(SET_THEME, (theme: any) => {
         window.store.dispatch({
@@ -87,26 +90,21 @@ export const decorateTerm = (Term: any) =>
       })
     }
 
-    private setLoaded() {
-      this.setState({imageLoaded: true});
-    }
-
-    componentWillReceiveProps(nextProps: any){
+    componentWillReceiveProps(nextProps: any) {
       const themeState: ThemeState = this.props[THEME_STATE]
       const nextThemeState: ThemeState = nextProps[THEME_STATE];
-      if(themeState.activeTheme.sticker !== nextThemeState.activeTheme.sticker){
+      if (themeState.activeTheme.sticker !== nextThemeState.activeTheme.sticker) {
         this.setState({imageLoaded: false});
       }
-
     }
 
     render() {
       const themeState: ThemeState = this.props[THEME_STATE];
 
       const imageStyle = window.screen.width <= 1920 ?
-        { maxHeight: '200px' } : {}
+        {maxHeight: '200px'} : {}
       return (
-        <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+        <div style={{width: '100%', height: '100%', position: 'relative'}}>
           {React.createElement(Term, Object.assign({}, this.props))}
           <div style={{
             position: 'absolute',
@@ -117,9 +115,10 @@ export const decorateTerm = (Term: any) =>
             {
               themeState.showSticker ?
                 <img
-                  style={this.state.imageLoaded ? imageStyle : { display: 'none' }}
-                  onLoad={()=>this.setLoaded()}
-                  src={this.constructStickerUrl(themeState)}
+                  style={this.state.imageLoaded ? imageStyle : {display: 'none'}}
+                  onLoad={() => this.setLoaded()}
+                  src={TerminalDecorator.constructStickerUrl(themeState)}
+                  alt={themeState.activeTheme.sticker}
                 /> : <></>
             }
           </div>
@@ -127,7 +126,11 @@ export const decorateTerm = (Term: any) =>
       )
     }
 
-    private constructStickerUrl(themeState: ThemeState): string | undefined {
+    private setLoaded() {
+      this.setState({imageLoaded: true});
+    }
+
+    private static constructStickerUrl(themeState: ThemeState): string | undefined {
       const localStickerPath = resolveLocalStickerPath(themeState.activeTheme.sticker).replace(path.sep, '/');
       return `${localStickerPath}?time=${new Date().valueOf().toString(32)}`;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-import { attemptToUpdateSticker } from './StickerUpdateService';
-
-attemptToUpdateSticker();
-
 export { default as reduceUI } from './reducer';
 
 export { decorateConfig } from './config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export { default as reduceUI } from './reducer';
+export {default as reduceUI} from './reducer';
 
-export { decorateConfig } from './config';
+export {decorateConfig} from './config';
 
 export {
   decorateHyper,
@@ -11,4 +11,4 @@ export {
   getTermProps
 } from './decorator';
 
-export {default as decorateMenu } from './settings';
+export {default as decorateMenu} from './settings';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+import { attemptToUpdateSticker } from './StickerUpdateService';
+
+attemptToUpdateSticker();
+
 export { default as reduceUI } from './reducer';
 
 export { decorateConfig } from './config';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -28,7 +28,7 @@ const themes = Object.values(DokiThemeDefinitions)
     }
   });
 
-export const VERSION = 'v2.0.0';
+export const VERSION = 'v2.0.1';
 const appName = 'Doki Theme';
 const icon = path.resolve(__dirname, '..', 'assets', 'Doki-Theme.png');
 const showAbout = () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@ import DokiThemeDefinitions from "./DokiThemeDefinitions";
 import { saveConfig, extractConfig } from "./config";
 import {dialog} from 'electron';
 import path from 'path';
+import { attemptToUpdateSticker } from "./StickerUpdateService";
 
 export const SET_THEME = 'SET_THEME'
 export const TOGGLE_STICKER = 'TOGGLE_STICKER';
@@ -57,6 +58,7 @@ const getAboutMenu = () =>{
 };
 
 export default (menu:any) => {
+  attemptToUpdateSticker();
   const menuItem = {
     id: 'Doki-Theme',
     label: 'Doki-Theme Settings',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,6 @@
 import DokiThemeDefinitions from "./DokiThemeDefinitions";
 import { saveConfig, extractConfig } from "./config";
-import {dialog} from 'electron';
+import {dialog, app} from 'electron';
 import path from 'path';
 import { attemptToUpdateSticker } from "./StickerUpdateService";
 
@@ -12,6 +12,7 @@ const themes = Object.values(DokiThemeDefinitions)
   return {
     label: dokiDefinition.information.name,
     click: async (_: any, focusedWindow: any) => {
+      await attemptToUpdateSticker(focusedWindow);
       focusedWindow.rpc.emit(SET_THEME, dokiDefinition);
       saveConfig(
         {
@@ -58,7 +59,6 @@ const getAboutMenu = () =>{
 };
 
 export default (menu:any) => {
-  attemptToUpdateSticker();
   const menuItem = {
     id: 'Doki-Theme',
     label: 'Doki-Theme Settings',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,18 +1,19 @@
 import DokiThemeDefinitions from "./DokiThemeDefinitions";
 import { saveConfig, extractConfig } from "./config";
-import {dialog, app} from 'electron';
+import {dialog, app, ipcRenderer} from 'electron';
 import path from 'path';
 import { attemptToUpdateSticker } from "./StickerUpdateService";
+import AppInitialization from "./AppInitialization";
 
 export const SET_THEME = 'SET_THEME'
 export const TOGGLE_STICKER = 'TOGGLE_STICKER';
+export const STICKER_UPDATED = 'STICKER_UPDATED';
 
 const themes = Object.values(DokiThemeDefinitions)
 .map(dokiDefinition => {
   return {
     label: dokiDefinition.information.name,
     click: async (_: any, focusedWindow: any) => {
-      await attemptToUpdateSticker(focusedWindow);
       focusedWindow.rpc.emit(SET_THEME, dokiDefinition);
       saveConfig(
         {
@@ -58,7 +59,10 @@ const getAboutMenu = () =>{
   }
 };
 
+
+
 export default (menu:any) => {
+  AppInitialization();
   const menuItem = {
     id: 'Doki-Theme',
     label: 'Doki-Theme Settings',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,7 +62,6 @@ const getAboutMenu = () => {
   }
 };
 
-
 export default (menu: any) => {
   AppInitialization();
   const menuItem = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,10 @@ const themes = Object.values(DokiThemeDefinitions)
     label: dokiDefinition.information.name,
     click: async (_: any, focusedWindow: any) => {
       focusedWindow.rpc.emit(SET_THEME, dokiDefinition);
+      setTimeout(()=>{
+        // triggers event loop to continue download?
+        focusedWindow.rpc.emit('refresh'); 
+      }, 500);
       saveConfig(
         {
           ...extractConfig(),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,8 +1,7 @@
 import DokiThemeDefinitions from "./DokiThemeDefinitions";
-import { saveConfig, extractConfig } from "./config";
-import {dialog, app, ipcRenderer} from 'electron';
+import {extractConfig, saveConfig} from "./config";
+import {dialog} from 'electron';
 import path from 'path';
-import { attemptToUpdateSticker } from "./StickerUpdateService";
 import AppInitialization from "./AppInitialization";
 
 export const SET_THEME = 'SET_THEME'
@@ -10,20 +9,20 @@ export const TOGGLE_STICKER = 'TOGGLE_STICKER';
 export const STICKER_UPDATED = 'STICKER_UPDATED';
 
 const themes = Object.values(DokiThemeDefinitions)
-.map(dokiDefinition => {
-  return {
-    label: dokiDefinition.information.name,
-    click: async (_: any, focusedWindow: any) => {
-      focusedWindow.rpc.emit(SET_THEME, dokiDefinition);
-      setTimeout(()=>{
-        // triggers event loop to continue download?
-        focusedWindow.rpc.emit('refresh'); 
-      }, 500);
-      saveConfig(
-        {
-          ...extractConfig(),
-          themeId: dokiDefinition.information.id
-        }
+  .map(dokiDefinition => {
+    return {
+      label: dokiDefinition.information.name,
+      click: async (_: any, focusedWindow: any) => {
+        focusedWindow.rpc.emit(SET_THEME, dokiDefinition);
+        setTimeout(() => {
+          // triggers event loop to continue download?
+          focusedWindow.rpc.emit('refresh');
+        }, 500);
+        saveConfig(
+          {
+            ...extractConfig(),
+            themeId: dokiDefinition.information.id
+          }
         )
       }
     }
@@ -43,8 +42,8 @@ const showAbout = () => {
   });
 };
 
-const getAboutMenu = () =>{
-  if(process.platform !== 'darwin') {
+const getAboutMenu = () => {
+  if (process.platform !== 'darwin') {
     return {
       role: 'about',
       click() {
@@ -64,8 +63,7 @@ const getAboutMenu = () =>{
 };
 
 
-
-export default (menu:any) => {
+export default (menu: any) => {
   AppInitialization();
   const menuItem = {
     id: 'Doki-Theme',
@@ -92,7 +90,7 @@ export default (menu:any) => {
           saveConfig(
             {
               ...savedConfig,
-              showSticker: !savedConfig.showSticker 
+              showSticker: !savedConfig.showSticker
             }
           )
         }
@@ -101,7 +99,7 @@ export default (menu:any) => {
       {
         label: 'View ChangeLog',
         click: async () => {
-          const { shell } = require('electron');
+          const {shell} = require('electron');
           await shell.openExternal('https://github.com/Unthrottled/doki-theme-hyper/blob/master/CHANGELOG.md')
         }
       }
@@ -110,6 +108,6 @@ export default (menu:any) => {
 
   return [
     ...menu,
-    menuItem    
+    menuItem
   ]
 };


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail -->
Wiring the plugin into my assets infrastructure.
Plugin checks to see if the current sticker being used is the most up to date.
If the sticker is not the same in the infrastructure, then it downloads and sets that as the current used sticker.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Right now all of the stickers are drawn in all different styles, I eventually want to migrate them to look roughly like this style:

Just Monika            |  Natsuki | Mioda Ibuki
:-------------------------:|:-------------------------:|:-------------------------:
![Just Monika](https://doki.assets.unthrottled.io/stickers/vscode/literature/monika/light/just_monika.png) | ![natsuki](https://doki.assets.unthrottled.io/stickers/vscode/literature/natsuki/light/natsuki.png) | ![image](https://doki.assets.unthrottled.io/stickers/vscode/danganronpa/ibuki/light/ibuki_light.png)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
It works offline if you have already downloaded the sticker.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.